### PR TITLE
CTM-628 Fix up Leonardo disk type menu

### DIFF
--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -763,7 +763,7 @@ export const generateTestDisk = (overrides: Partial<PersistentDisk> = {}): Persi
   blockSize: 4096,
   diskType: {
     value: 'pd-standard',
-    label: 'Standard',
+    label: 'Hard Disk',
     regionToPricesName: 'monthlyStandardDiskPrice',
   },
   cloudContext: {

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.test.ts
@@ -73,7 +73,7 @@ describe('GcpPersistentDiskSection', () => {
 
     // Assert
     expect(screen.getByLabelText('Disk Type')).toBeDisabled();
-    expect(screen.getByText('Standard')).toBeTruthy();
+    expect(screen.getByText('Hard Disk')).toBeTruthy();
     expect(screen.getByLabelText('Disk Size (GB)')).toBeEnabled();
   });
 });

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.ts
@@ -9,7 +9,7 @@ import { defaultPersistentDiskType } from 'src/analysis/utils/disk-utils';
 import { GooglePdType, googlePdTypes } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { CloudProvider } from 'src/workspaces/utils';
 
-export const GcpPersistentDiskOptions = [googlePdTypes.standard, googlePdTypes.balanced, googlePdTypes.ssd];
+export const GcpPersistentDiskOptions = [googlePdTypes.ssd, googlePdTypes.balanced, googlePdTypes.standard];
 
 export interface GcpPersistentDiskSectionProps {
   persistentDiskExists: boolean;

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
@@ -30,7 +30,7 @@ export const PersistentDiskTypeInput = <T extends DiskType, Option extends { val
         isDisabled,
         options,
         id: persistentDiskId,
-        menuPlacement: 'auto',
+        menuPlacement: 'top',
       }),
     ]),
   ]);

--- a/src/analysis/utils/disk-utils.ts
+++ b/src/analysis/utils/disk-utils.ts
@@ -16,7 +16,7 @@ export const defaultDataprocWorkerDiskSize = 150;
 // with a PD has been non-user-customizable. Terra UI uses the value below for cost estimate calculations only.
 export const defaultGceBootDiskSize = 250;
 export const defaultGcePersistentDiskSize = 50;
-export const defaultPersistentDiskType = googlePdTypes.standard;
+export const defaultPersistentDiskType = googlePdTypes.ssd;
 export const getCurrentAttachedDataDisk = (
   app: App | undefined,
   appDataDisks: PersistentDisk[]

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
@@ -65,7 +65,7 @@ export type PDLabels = 'standard' | 'balanced' | 'ssd';
 export const googlePdTypes: Record<PDLabels, GooglePdType> = {
   standard: {
     value: 'pd-standard',
-    label: 'Standard',
+    label: 'Hard Disk',
     regionToPricesName: 'monthlyStandardDiskPrice',
   },
   balanced: {
@@ -75,7 +75,7 @@ export const googlePdTypes: Record<PDLabels, GooglePdType> = {
   },
   ssd: {
     value: 'pd-ssd',
-    label: 'Solid state drive (SSD)',
+    label: 'Solid State Drive (default)',
     regionToPricesName: 'monthlySSDDiskPrice',
   },
 };


### PR DESCRIPTION
**Before:** The option that gives the user the best experience is unreachable off the bottom of the page (unless you know to scroll more). This is an accessibility issue, as users without trackpad/scroll wheel cannot reach it at all.

<img width="500" alt="Screenshot 2026-08-20 at 10 40 56" src="https://github.com/user-attachments/assets/e62b84c2-bc36-4db9-ae9e-96eb83eb75e3" />

---

**After:** Menu opens upward and all options are reachable. SSD option is now defaulted.

Remove the word "Standard", as that made it seem like we endorsed it as the default choice; when in fact that is Google's terminology leaking into our product.

<img width="500" alt="Screenshot 2026-08-20 at 11 22 57" src="https://github.com/user-attachments/assets/8ea2f32c-07e1-4eb7-a8d0-6fdbb5fcb9ae" />