### PR TITLE
[TSPS-1189] Reformat Helpful Tips section in Run Job page

### DIFF
--- a/src/pages/scientificServices/pipelines/common/zendeskUtils.test.tsx
+++ b/src/pages/scientificServices/pipelines/common/zendeskUtils.test.tsx
@@ -4,8 +4,8 @@ import { DocsKey, ZendeskLink, zendeskUrl } from 'src/pages/scientificServices/p
 
 describe('zendeskUtils', () => {
   describe('zendeskUrl', () => {
-    it('returns the correct URL for INPUT_REQ', () => {
-      expect(zendeskUrl(DocsKey.INPUT_REQ)).toBe(
+    it('returns the correct URL for ARRAY_IMPUTATION_INPUT_REQ', () => {
+      expect(zendeskUrl(DocsKey.ARRAY_IMPUTATION_INPUT_REQ)).toBe(
         'https://broadscientificservices.zendesk.com/hc/en-us/articles/40161675448859'
       );
     });

--- a/src/pages/scientificServices/pipelines/common/zendeskUtils.test.tsx
+++ b/src/pages/scientificServices/pipelines/common/zendeskUtils.test.tsx
@@ -10,6 +10,24 @@ describe('zendeskUtils', () => {
       );
     });
 
+    it('returns the correct URL for CLOUD_INPUTS', () => {
+      expect(zendeskUrl(DocsKey.CLOUD_INPUTS)).toBe(
+        'https://broadscientificservices.zendesk.com/hc/en-us/articles/47099858889243'
+      );
+    });
+
+    it('returns the correct URL for CLOUD_OUTPUTS', () => {
+      expect(zendeskUrl(DocsKey.CLOUD_OUTPUTS)).toBe(
+        'https://broadscientificservices.zendesk.com/hc/en-us/articles/48878810499483'
+      );
+    });
+
+    it('returns the correct URL for LOW_PASS_IMPUTATION_INPUT_REQ', () => {
+      expect(zendeskUrl(DocsKey.LOW_PASS_IMPUTATION_INPUT_REQ)).toBe(
+        'https://broadscientificservices.zendesk.com/hc/en-us/articles/50837430347675-Input-Requirements'
+      );
+    });
+
     it('returns the default URL for an unknown DocsKey', () => {
       // @ts-expect-error Testing invalid key
       expect(zendeskUrl('UNKNOWN_KEY')).toBe(
@@ -33,6 +51,29 @@ describe('zendeskUtils', () => {
         'https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035'
       );
       expect(linkElement).toHaveStyle('font-weight: italics');
+    });
+
+    it('renders correctly for the CLOUD_INPUTS docs key', () => {
+      const { getByText } = render(
+        <ZendeskLink docsKey={DocsKey.CLOUD_INPUTS}>provide inputs from the cloud</ZendeskLink>
+      );
+
+      const linkElement = getByText('provide inputs from the cloud');
+      expect(linkElement).toBeInTheDocument();
+      expect(linkElement).toHaveAttribute(
+        'href',
+        'https://broadscientificservices.zendesk.com/hc/en-us/articles/47099858889243'
+      );
+    });
+
+    it('opens in a new tab and has the expected default style when no additionalStyle is provided', () => {
+      const { getByText } = render(<ZendeskLink docsKey={DocsKey.CLOUD_OUTPUTS}>cloud outputs link</ZendeskLink>);
+
+      const linkElement = getByText('cloud outputs link');
+      expect(linkElement).toHaveAttribute('target', '_blank');
+      expect(linkElement).toHaveAttribute('rel', 'noreferrer');
+      expect(linkElement).toHaveStyle('color: #46A3E9');
+      expect(linkElement).toHaveStyle('text-decoration: underline');
     });
   });
 });

--- a/src/pages/scientificServices/pipelines/common/zendeskUtils.tsx
+++ b/src/pages/scientificServices/pipelines/common/zendeskUtils.tsx
@@ -4,20 +4,23 @@ import React from 'react';
 export enum DocsKey {
   GETTING_STARTED = 'GETTING_STARTED',
   ABOUT_SERVICE = 'ABOUT_SERVICE',
-  INPUT_REQ = 'INPUT_REQ',
+  ARRAY_IMPUTATION_INPUT_REQ = 'ARRAY_IMPUTATION_INPUT_REQ',
   QUOTA_DETAILS = 'QUOTA_DETAILS',
   CLOUD_INPUTS = 'CLOUD_INPUTS',
   CLOUD_OUTPUTS = 'CLOUD_OUTPUTS',
+  LOW_PASS_IMPUTATION_INPUT_REQ = 'LOW_PASS_IMPUTATION_INPUT_REQ',
 }
 
 // Mapping of documentation keys to their respective Zendesk URLs
 const ZENDESK_PAGES: Record<DocsKey, string> = {
   GETTING_STARTED: 'https://broadscientificservices.zendesk.com/hc/en-us/sections/39901025462171',
   ABOUT_SERVICE: 'https://broadscientificservices.zendesk.com/hc/en-us/categories/39900993442459',
-  INPUT_REQ: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/40161675448859',
+  ARRAY_IMPUTATION_INPUT_REQ: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/40161675448859',
   QUOTA_DETAILS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035',
   CLOUD_INPUTS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/47099858889243',
   CLOUD_OUTPUTS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/48878810499483',
+  LOW_PASS_IMPUTATION_INPUT_REQ:
+    'https://broadscientificservices.zendesk.com/hc/en-us/articles/50837430347675-Input-Requirements',
 };
 
 // Retrieve the Zendesk URL based on the provided documentation key

--- a/src/pages/scientificServices/pipelines/common/zendeskUtils.tsx
+++ b/src/pages/scientificServices/pipelines/common/zendeskUtils.tsx
@@ -5,10 +5,10 @@ export enum DocsKey {
   GETTING_STARTED = 'GETTING_STARTED',
   ABOUT_SERVICE = 'ABOUT_SERVICE',
   ARRAY_IMPUTATION_INPUT_REQ = 'ARRAY_IMPUTATION_INPUT_REQ',
+  LOW_PASS_IMPUTATION_INPUT_REQ = 'LOW_PASS_IMPUTATION_INPUT_REQ',
   QUOTA_DETAILS = 'QUOTA_DETAILS',
   CLOUD_INPUTS = 'CLOUD_INPUTS',
   CLOUD_OUTPUTS = 'CLOUD_OUTPUTS',
-  LOW_PASS_IMPUTATION_INPUT_REQ = 'LOW_PASS_IMPUTATION_INPUT_REQ',
 }
 
 // Mapping of documentation keys to their respective Zendesk URLs
@@ -16,11 +16,11 @@ const ZENDESK_PAGES: Record<DocsKey, string> = {
   GETTING_STARTED: 'https://broadscientificservices.zendesk.com/hc/en-us/sections/39901025462171',
   ABOUT_SERVICE: 'https://broadscientificservices.zendesk.com/hc/en-us/categories/39900993442459',
   ARRAY_IMPUTATION_INPUT_REQ: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/40161675448859',
+  LOW_PASS_IMPUTATION_INPUT_REQ:
+    'https://broadscientificservices.zendesk.com/hc/en-us/articles/50837430347675-Input-Requirements',
   QUOTA_DETAILS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035',
   CLOUD_INPUTS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/47099858889243',
   CLOUD_OUTPUTS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/48878810499483',
-  LOW_PASS_IMPUTATION_INPUT_REQ:
-    'https://broadscientificservices.zendesk.com/hc/en-us/articles/50837430347675-Input-Requirements',
 };
 
 // Retrieve the Zendesk URL based on the provided documentation key

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -533,6 +533,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
         )}
       </div>
       <div>
+        <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
         <QuotaDetailsWidget
           selectedPipeline={selectedPipeline}
           quota={quota}
@@ -541,7 +542,6 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
           isLoading={isLoadingQuota}
         />
         <PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />
-        <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
       </div>
     </div>
   );

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/LocalFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/LocalFileInput.tsx
@@ -58,7 +58,9 @@ export const LocalFileInput: React.FC<LocalFileInputProps> = ({
           </span>
           <div style={{ marginTop: '0.5rem' }}>
             <Icon icon='info-circle' size={16} style={{ color: colors.primary(), verticalAlign: 'middle' }} />{' '}
-            <ZendeskLink docsKey={DocsKey.INPUT_REQ}>Learn more about how to reduce your file size.</ZendeskLink>
+            <ZendeskLink docsKey={DocsKey.ARRAY_IMPUTATION_INPUT_REQ}>
+              Learn more about how to reduce your file size.
+            </ZendeskLink>
           </div>
         </>
       );

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.test.tsx
@@ -4,20 +4,55 @@ import { mockPipeline } from 'src/pages/scientificServices/pipelines/utils/mock-
 
 import { HelpfulTipsWidget, PIPELINE_TIPS } from './HelpfulTipsWidget';
 
-describe('HelpfulTips', () => {
-  it('renders all tips for a pipeline', () => {
+describe('HelpfulTipsWidget', () => {
+  it('renders the widget title and pipeline-specific tips for a pipeline with tips', () => {
     render(<HelpfulTipsWidget selectedPipeline={mockPipeline('array_imputation')} />);
 
-    expect(screen.getByText('Helpful Tips')).toBeInTheDocument();
+    expect(screen.getByText('Getting Started + Helpful Hints')).toBeInTheDocument();
+    expect(screen.getByText('Input requirements:')).toBeInTheDocument();
 
     PIPELINE_TIPS.array_imputation.forEach((tip) => {
       expect(screen.getByTestId(`tip-${tip.id}`)).toBeInTheDocument();
     });
+
+    expect(screen.getByTestId('tip-cloud-inputs')).toBeInTheDocument();
+    expect(screen.getByTestId('tip-cloud-outputs')).toBeInTheDocument();
   });
 
-  it('does not display the widget if a pipeline doesnt have tips', () => {
-    render(<HelpfulTipsWidget selectedPipeline={mockPipeline('some_fake_pipeline')} />);
+  it('always renders the common cloud inputs/outputs tips, regardless of pipeline', () => {
+    render(<HelpfulTipsWidget selectedPipeline={mockPipeline('new_imputation_pipeline')} />);
 
-    expect(screen.queryByText('Helpful Tips')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tip-cloud-inputs')).toBeInTheDocument();
+    expect(screen.getByTestId('tip-cloud-outputs')).toBeInTheDocument();
+  });
+
+  it('does not render the "Input requirements" section for a pipeline without specific tips', () => {
+    render(<HelpfulTipsWidget selectedPipeline={mockPipeline('new_imputation_pipeline')} />);
+
+    expect(screen.queryByText('Input requirements:')).not.toBeInTheDocument();
+  });
+
+  it('still renders the widget and common tips for a pipeline without specific tips', () => {
+    render(<HelpfulTipsWidget selectedPipeline={mockPipeline('new_imputation_pipeline')} />);
+
+    expect(screen.getByText('Getting Started + Helpful Hints')).toBeInTheDocument();
+    expect(screen.getByTestId('tip-cloud-inputs')).toBeInTheDocument();
+    expect(screen.getByTestId('tip-cloud-outputs')).toBeInTheDocument();
+  });
+
+  it('does not render the widget when no pipeline is selected', () => {
+    render(<HelpfulTipsWidget selectedPipeline={undefined} />);
+
+    expect(screen.queryByText('Getting Started + Helpful Hints')).not.toBeInTheDocument();
+  });
+
+  it('renders tips for a different pipeline (low_pass_imputation)', () => {
+    render(<HelpfulTipsWidget selectedPipeline={mockPipeline('low_pass_imputation')} />);
+
+    PIPELINE_TIPS.low_pass_imputation.forEach((tip) => {
+      expect(screen.getByTestId(`tip-${tip.id}`)).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('tip-cloud-inputs')).toBeInTheDocument();
+    expect(screen.getByTestId('tip-cloud-outputs')).toBeInTheDocument();
   });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.tsx
@@ -63,7 +63,7 @@ export const HelpfulTipsWidget = ({ selectedPipeline }: { selectedPipeline?: Pip
   const pipelineTips = PIPELINE_TIPS[selectedPipeline.pipelineName] ?? [];
 
   return (
-    <PipelineWidgetContainer title='Getting Started + Helpful Hints' padding='1rem' backgroundColor='#eef7f2'>
+    <PipelineWidgetContainer title='Getting Started + Helpful Hints' padding='1rem' backgroundColor='#eaf3fb'>
       <ul style={{ paddingInlineStart: '1.5rem' }}>
         {pipelineTips.length > 0 && (
           <li style={{ marginTop: '1rem' }}>

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.tsx
@@ -14,25 +14,70 @@ export const PIPELINE_TIPS: Record<string, { id: string; content: ReactNode }[]>
       id: 'format-guidelines',
       content: (
         <>
-          View{' '}
-          <ZendeskLink docsKey={DocsKey.INPUT_REQ} additionalStyle={{ fontWeight: 'bold' }}>
-            formatting guidelines
-          </ZendeskLink>{' '}
-          for input VCF files
+          View <ZendeskLink docsKey={DocsKey.ARRAY_IMPUTATION_INPUT_REQ}>formatting guidelines</ZendeskLink> for input
+          VCF files
+        </>
+      ),
+    },
+  ],
+  low_pass_imputation: [
+    {
+      id: 'quota-check',
+      content: 'Ensure your manifest file contains no more cram file paths than your remaining quota',
+    },
+    {
+      id: 'format-guidelines',
+      content: (
+        <>
+          View <ZendeskLink docsKey={DocsKey.LOW_PASS_IMPUTATION_INPUT_REQ}>guidelines</ZendeskLink> for manifest file
         </>
       ),
     },
   ],
 };
 
+// Tips shown for every pipeline
+const COMMON_TIPS: { id: string; content: ReactNode }[] = [
+  {
+    id: 'cloud-inputs',
+    content: (
+      <>
+        Learn how to <ZendeskLink docsKey={DocsKey.CLOUD_INPUTS}>provide inputs from Google Cloud</ZendeskLink>
+      </>
+    ),
+  },
+  {
+    id: 'cloud-outputs',
+    content: (
+      <>
+        Learn how{' '}
+        <ZendeskLink docsKey={DocsKey.CLOUD_OUTPUTS}>outputs can be delivered to the Google Cloud</ZendeskLink>
+      </>
+    ),
+  },
+];
+
 export const HelpfulTipsWidget = ({ selectedPipeline }: { selectedPipeline?: Pipeline }) => {
-  const pipelineTips = selectedPipeline && PIPELINE_TIPS[selectedPipeline.pipelineName];
-  if (!pipelineTips || pipelineTips.length === 0) return null;
+  if (!selectedPipeline) return null;
+
+  const pipelineTips = PIPELINE_TIPS[selectedPipeline.pipelineName] ?? [];
 
   return (
-    <PipelineWidgetContainer title='Helpful Tips' padding='1rem'>
+    <PipelineWidgetContainer title='Getting Started + Helpful Hints' padding='1rem' backgroundColor='#eef7f2'>
       <ul style={{ paddingInlineStart: '1.5rem' }}>
-        {pipelineTips.map((tip) => (
+        {pipelineTips.length > 0 && (
+          <li style={{ marginTop: '1rem' }}>
+            Input requirements:
+            <ul style={{ paddingInlineStart: '1.5rem' }}>
+              {pipelineTips.map((tip) => (
+                <li key={tip.id} data-testid={`tip-${tip.id}`} style={{ marginTop: '0.5rem' }}>
+                  {tip.content}
+                </li>
+              ))}
+            </ul>
+          </li>
+        )}
+        {COMMON_TIPS.map((tip) => (
           <li key={tip.id} data-testid={`tip-${tip.id}`} style={{ marginTop: '1rem' }}>
             {tip.content}
           </li>

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/HelpfulTipsWidget.tsx
@@ -14,8 +14,11 @@ export const PIPELINE_TIPS: Record<string, { id: string; content: ReactNode }[]>
       id: 'format-guidelines',
       content: (
         <>
-          View <ZendeskLink docsKey={DocsKey.ARRAY_IMPUTATION_INPUT_REQ}>formatting guidelines</ZendeskLink> for input
-          VCF files
+          View{' '}
+          <ZendeskLink docsKey={DocsKey.ARRAY_IMPUTATION_INPUT_REQ} additionalStyle={{ color: '#0b5394' }}>
+            formatting guidelines
+          </ZendeskLink>{' '}
+          for input VCF files
         </>
       ),
     },
@@ -29,7 +32,11 @@ export const PIPELINE_TIPS: Record<string, { id: string; content: ReactNode }[]>
       id: 'format-guidelines',
       content: (
         <>
-          View <ZendeskLink docsKey={DocsKey.LOW_PASS_IMPUTATION_INPUT_REQ}>guidelines</ZendeskLink> for manifest file
+          View{' '}
+          <ZendeskLink docsKey={DocsKey.LOW_PASS_IMPUTATION_INPUT_REQ} additionalStyle={{ color: '#0b5394' }}>
+            guidelines
+          </ZendeskLink>{' '}
+          for the manifest file
         </>
       ),
     },
@@ -42,7 +49,10 @@ const COMMON_TIPS: { id: string; content: ReactNode }[] = [
     id: 'cloud-inputs',
     content: (
       <>
-        Learn how to <ZendeskLink docsKey={DocsKey.CLOUD_INPUTS}>provide inputs from Google Cloud</ZendeskLink>
+        Learn how{' '}
+        <ZendeskLink docsKey={DocsKey.CLOUD_INPUTS} additionalStyle={{ color: '#0b5394' }}>
+          provide inputs from Google Cloud
+        </ZendeskLink>
       </>
     ),
   },
@@ -51,7 +61,9 @@ const COMMON_TIPS: { id: string; content: ReactNode }[] = [
     content: (
       <>
         Learn how{' '}
-        <ZendeskLink docsKey={DocsKey.CLOUD_OUTPUTS}>outputs can be delivered to the Google Cloud</ZendeskLink>
+        <ZendeskLink docsKey={DocsKey.CLOUD_OUTPUTS} additionalStyle={{ color: '#0b5394' }}>
+          outputs can be delivered to the Google Cloud
+        </ZendeskLink>
       </>
     ),
   },

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineWidgetContainer.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineWidgetContainer.tsx
@@ -8,6 +8,7 @@ interface PipelineWidgetWrapperProps {
   marginBottom?: string;
   width?: string;
   padding?: string;
+  backgroundColor?: string;
 }
 
 // Wrapper component for sidebar widgets to ensure consistent styling
@@ -18,13 +19,14 @@ export const PipelineWidgetContainer = ({
   marginBottom = '1rem',
   width = '400px',
   padding = '1rem 1rem 1.5rem',
+  backgroundColor = '#f4f6f9',
 }: PipelineWidgetWrapperProps) => {
   return (
     <div
       style={{
         marginTop,
         marginBottom,
-        backgroundColor: '#f4f6f9',
+        backgroundColor,
         width,
         padding,
         borderRadius: '4px',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-1189

### What
This PR reformats the Helpful Tips section to Getting Started + Helpful Hints. It is now moved to top of the right panel, above Quota details. It will contain pipeline specific links like input requirements as well as general cloud inputs/outputs links.

### Testing strategy
- [x] manual testing
- [x] unit tests

### Visual Aids
Before -- it was displayed at bottom of the page
<img width="1487" height="682" alt="Screenshot 2026-09-04 at 6 18 29 PM" src="https://github.com/user-attachments/assets/1b324098-237b-46b1-aaec-b2b92bd727cd" />

After
<img width="1508" height="688" alt="Screenshot 2026-09-04 at 6 17 20 PM" src="https://github.com/user-attachments/assets/0c3b388c-7636-4f4f-9157-1d09cdb1c9b6" />

Array imputation
<img width="439" height="278" alt="Screenshot 2026-09-04 at 6 17 30 PM" src="https://github.com/user-attachments/assets/5ddb3a89-89ee-464e-978a-9b1b16e34f96" />


Low pass pipeline
<img width="447" height="286" alt="Screenshot 2026-09-04 at 6 17 41 PM" src="https://github.com/user-attachments/assets/206a5376-75c1-497c-b6d8-260c83649487" />


SV pipeline (only visible in dev) -- still shows the cloud inputs and delivery links as default
<img width="439" height="190" alt="Screenshot 2026-09-04 at 6 18 00 PM" src="https://github.com/user-attachments/assets/fc70e39c-17c7-4cdd-9ce1-0b895fab184d" />



