### PR TITLE
[TSPS-1172] Add support for FILE_ARRAY pipeline output type

### DIFF
--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -5,7 +5,7 @@ export interface Pipeline {
   description: string;
 }
 
-export type PipelineIOType = 'FILE' | 'STRING' | 'FLOAT' | 'BOOLEAN' | 'MANIFEST';
+export type PipelineIOType = 'FILE' | 'STRING' | 'FLOAT' | 'BOOLEAN' | 'MANIFEST' | 'FILE_ARRAY';
 
 export interface PipelineInput {
   name: string;
@@ -152,7 +152,8 @@ export interface PipelineRunReport {
   pipelineName: string;
   pipelineVersion: number;
   toolVersion: string;
-  outputs?: Record<string, PipelineOutputValue>;
+  // FILE_ARRAY outputs are represented as an array of values; all other output types are a single value
+  outputs?: Record<string, PipelineOutputValue | PipelineOutputValue[]>;
   userInputs?: Record<string, string>;
   outputExpirationDate?: string;
   inputSize?: number;
@@ -164,7 +165,8 @@ export interface PipelineRunReport {
 
 export interface PipelineRunOutputSignedUrlsResponse {
   jobId: string;
-  outputSignedUrls: Record<string, string>;
+  // FILE_ARRAY outputs have one signed URL per file, in the same order as the corresponding output array
+  outputSignedUrls: Record<string, string | string[]>;
   outputExpirationDate: string;
 }
 

--- a/src/pages/scientificServices/pipelines/hooks/usePipelineDetails.ts
+++ b/src/pages/scientificServices/pipelines/hooks/usePipelineDetails.ts
@@ -10,10 +10,14 @@ export interface UsePipelineDetailsResult {
   error: Error | undefined;
 }
 
-export const usePipelineDetails = (pipelineName: string, pipelineVersion: number): UsePipelineDetailsResult => {
+export const usePipelineDetails = (
+  pipelineName: string,
+  pipelineVersion: number,
+  enabled = true
+): UsePipelineDetailsResult => {
   const signal = useCancellation();
   const [pipelineDetails, setPipelineDetails] = useState<PipelineWithDetails | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(enabled);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   const fetchPipelineDetails = async () => {
@@ -34,8 +38,12 @@ export const usePipelineDetails = (pipelineName: string, pipelineVersion: number
   };
 
   useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
     fetchPipelineDetails();
-  }, [pipelineName, pipelineVersion, signal]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pipelineName, pipelineVersion, enabled, signal]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     pipelineDetails,

--- a/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import * as Nav from 'src/libs/nav';
 import { getOutputFileSize } from 'src/pages/scientificServices/pipelines/utils/file-utils';
+import { MOCK_FILE_ARRAY_JOB_ID } from 'src/pages/scientificServices/pipelines/utils/mock-file-array-example';
 import { mockPipelineRunResponse } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
@@ -88,6 +89,17 @@ describe('JobDetails', () => {
     await user.click(backButton);
 
     expect(Nav.goToPath).toHaveBeenCalledWith('pipelines-history');
+  });
+
+  it('renders the FILE_ARRAY preview fixture without calling the API when jobId is the mock sentinel', async () => {
+    render(<JobDetails jobId={MOCK_FILE_ARRAY_JOB_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('imputed multi-sample VCFs')).toBeInTheDocument();
+      expect(screen.getAllByText('file array').length).toBeGreaterThan(0);
+    });
+
+    expect(mockGetPipelineRunResult).not.toHaveBeenCalled();
   });
 
   describe('DataDeliveryView section', () => {

--- a/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.tsx
@@ -9,6 +9,11 @@ import { DataDeliveryView } from 'src/pages/scientificServices/pipelines/tabs/hi
 import { JobDetailsHeader } from 'src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader';
 import { JobIOView } from 'src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView';
 import { PipelineRunTimeline } from 'src/pages/scientificServices/pipelines/tabs/history/details/sections/timeline/PipelineRunTimeline';
+import {
+  MOCK_FILE_ARRAY_JOB_ID,
+  mockFileArrayPipelineDetails,
+  mockFileArrayPipelineRunResponse,
+} from 'src/pages/scientificServices/pipelines/utils/mock-file-array-example';
 
 export interface JobDetailsProps {
   jobId: string;
@@ -22,7 +27,10 @@ export const JobDetails = ({ jobId }: JobDetailsProps) => {
     async function fetchJobDetails() {
       setIsLoading(true);
       try {
-        const response = await Teaspoons().getPipelineRunResult(jobId);
+        const response =
+          jobId === MOCK_FILE_ARRAY_JOB_ID
+            ? mockFileArrayPipelineRunResponse
+            : await Teaspoons().getPipelineRunResult(jobId);
 
         setPipelineRunResult(response);
       } catch (err) {
@@ -72,7 +80,10 @@ export const JobDetails = ({ jobId }: JobDetailsProps) => {
                 )}
               </div>
               <div style={{ flex: 1 }}>
-                <JobIOView pipelineRunResult={pipelineRunResult} />
+                <JobIOView
+                  pipelineRunResult={pipelineRunResult}
+                  pipelineDetailsOverride={jobId === MOCK_FILE_ARRAY_JOB_ID ? mockFileArrayPipelineDetails : undefined}
+                />
               </div>
             </div>
           </div>

--- a/src/pages/scientificServices/pipelines/tabs/history/details/modals/OutputDetailsModal.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/modals/OutputDetailsModal.test.tsx
@@ -257,4 +257,59 @@ describe('OutputDetailsModal', () => {
     // should call getOutputFileSize when size metadata is not available
     expect(getOutputFileSize).toHaveBeenCalledWith('https://signed-url.com/output.vcf');
   });
+
+  describe('FILE_ARRAY outputs', () => {
+    const pipelineResultWithFileArray = {
+      ...mockPipelineRunResult,
+      pipelineRunReport: {
+        ...mockPipelineRunResult.pipelineRunReport,
+        outputs: {
+          imputedMultiSampleVcf: [
+            { value: 'test.chr1.vcf.gz', metadata: { sizeInBytes: 100 } },
+            { value: 'test.chr2.vcf.gz', metadata: { sizeInBytes: 200 } },
+          ],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      mockGetPipelineRunOutputSignedUrls.mockResolvedValue({
+        outputSignedUrls: {
+          imputedMultiSampleVcf: ['https://signed-url.com/test.chr1.vcf.gz', 'https://signed-url.com/test.chr2.vcf.gz'],
+        },
+      });
+    });
+
+    it('resolves the signed URL and size metadata at the given index', async () => {
+      renderModal({
+        pipelineRunResult: pipelineResultWithFileArray,
+        fileName: 'test.chr2.vcf.gz',
+        index: 1,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('test.chr2.vcf.gz')).toBeInTheDocument();
+        expect(screen.getByText('200 B')).toBeInTheDocument();
+      });
+
+      expect(getOutputFileSize).not.toHaveBeenCalled();
+
+      const user = userEvent.setup();
+      const downloadButton = screen.getByRole('button', { name: /download/i });
+      await user.click(downloadButton);
+
+      expect(mockWindowOpen).toHaveBeenCalledWith('https://signed-url.com/test.chr2.vcf.gz', '_blank');
+    });
+
+    it('shows an error when no index is provided for an array output', async () => {
+      renderModal({
+        pipelineRunResult: pipelineResultWithFileArray,
+        fileName: 'test.chr1.vcf.gz',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to retrieve download. Please try again.')).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/pages/scientificServices/pipelines/tabs/history/details/modals/OutputDetailsModal.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/modals/OutputDetailsModal.tsx
@@ -8,21 +8,36 @@ import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import { BucketConsoleLink } from 'src/pages/scientificServices/pipelines/tabs/run/inputs/file/BucketConsoleLink';
 import { getOutputFileSize } from 'src/pages/scientificServices/pipelines/utils/file-utils';
+import {
+  MOCK_FILE_ARRAY_JOB_ID,
+  mockFileArrayOutputSignedUrls,
+} from 'src/pages/scientificServices/pipelines/utils/mock-file-array-example';
 
 interface DownloadOutputModalProps {
   outputKey: string;
   outputDefinition?: PipelineOutput;
   fileName: string;
+  // Index into the output's value/signed-url arrays, for FILE_ARRAY outputs
+  index?: number;
   pipelineRunResult: PipelineRunResponse;
   onDismiss: () => void;
-  signedUrls?: Record<string, string>;
-  setSignedUrls: (urls: Record<string, string>) => void;
+  signedUrls?: Record<string, string | string[]>;
+  setSignedUrls: (urls: Record<string, string | string[]>) => void;
+}
+
+// Resolves a possibly-array value (FILE_ARRAY outputs/signed urls) at the given index, or returns it as-is otherwise
+function resolveAtIndex<T>(valueOrArray: T | T[] | undefined, index?: number): T | undefined {
+  if (!Array.isArray(valueOrArray)) {
+    return valueOrArray;
+  }
+  return index !== undefined ? valueOrArray[index] : undefined;
 }
 
 export const OutputDetailsModal = ({
   outputKey,
   outputDefinition,
   fileName,
+  index,
   pipelineRunResult,
   onDismiss,
   signedUrls,
@@ -49,12 +64,14 @@ export const OutputDetailsModal = ({
 
         // if we haven't already fetched signed urls for this job, do it! otherwise, we'll use the existing ones
         if (!urls) {
-          const response = await Teaspoons().getPipelineRunOutputSignedUrls(pipelineRunResult.jobReport.id);
-          urls = response.outputSignedUrls;
+          urls =
+            pipelineRunResult.jobReport.id === MOCK_FILE_ARRAY_JOB_ID
+              ? mockFileArrayOutputSignedUrls.outputSignedUrls
+              : (await Teaspoons().getPipelineRunOutputSignedUrls(pipelineRunResult.jobReport.id)).outputSignedUrls;
           setSignedUrls(urls);
         }
 
-        const url = urls?.[outputKey];
+        const url = resolveAtIndex(urls?.[outputKey], index);
         if (!url) {
           setError('Failed to retrieve download. Please try again.');
           return;
@@ -63,7 +80,10 @@ export const OutputDetailsModal = ({
         setSignedUrl(url);
 
         // if available, use the file size from the output metadata returned by the API
-        const outputMetadata = pipelineRunResult.pipelineRunReport.outputs?.[outputKey]?.metadata;
+        const outputMetadata = resolveAtIndex(
+          pipelineRunResult.pipelineRunReport.outputs?.[outputKey],
+          index
+        )?.metadata;
         if (outputMetadata?.sizeInBytes !== undefined) {
           setFileSize(formatBytes(outputMetadata.sizeInBytes));
         }
@@ -90,6 +110,7 @@ export const OutputDetailsModal = ({
   }, [
     deliverySucceeded,
     outputKey,
+    index,
     pipelineRunResult.jobReport.id,
     pipelineRunResult.pipelineRunReport.outputs,
     setSignedUrls,

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.test.tsx
@@ -33,7 +33,7 @@ describe('JobIOView', () => {
     const mockResult = mockPipelineRunResponse('SUCCEEDED');
     render(<JobIOView pipelineRunResult={mockResult} />);
 
-    expect(mockUsePipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
+    expect(mockUsePipelineDetails).toHaveBeenCalledWith('array_imputation', 1, true);
 
     await waitFor(() => {
       expect(screen.getByText('Inputs & Outputs')).toBeInTheDocument();

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.tsx
@@ -1,6 +1,6 @@
 import { Icon, Spinner } from '@terra-ui-packages/components';
 import React from 'react';
-import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { PipelineRunResponse, PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import { PipelineErrorMessage } from 'src/pages/scientificServices/pipelines/common/PipelineErrorMessage';
 import { usePipelineDetails } from 'src/pages/scientificServices/pipelines/hooks/usePipelineDetails';
@@ -9,16 +9,20 @@ import { JobOutputsView } from 'src/pages/scientificServices/pipelines/tabs/hist
 
 interface PipelineRunIOViewProps {
   pipelineRunResult: PipelineRunResponse;
+  // Bypasses the pipeline details fetch, e.g. to preview outputs types the backend doesn't return yet
+  pipelineDetailsOverride?: PipelineWithDetails;
 }
 
-export const JobIOView = ({ pipelineRunResult }: PipelineRunIOViewProps) => {
+export const JobIOView = ({ pipelineRunResult, pipelineDetailsOverride }: PipelineRunIOViewProps) => {
   const { pipelineDetails, isLoading } = usePipelineDetails(
     pipelineRunResult.pipelineRunReport.pipelineName,
-    pipelineRunResult.pipelineRunReport.pipelineVersion
+    pipelineRunResult.pipelineRunReport.pipelineVersion,
+    !pipelineDetailsOverride
   );
 
-  const inputDefinitions = pipelineDetails?.inputs || [];
-  const outputDefinitions = pipelineDetails?.outputs || [];
+  const effectivePipelineDetails = pipelineDetailsOverride || pipelineDetails;
+  const inputDefinitions = effectivePipelineDetails?.inputs || [];
+  const outputDefinitions = effectivePipelineDetails?.outputs || [];
 
   return (
     <div

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/datadelivery/DataDeliveryView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/datadelivery/DataDeliveryView.test.tsx
@@ -18,7 +18,7 @@ const pastExpirationDate = '2026-03-01T12:00:00.000Z';
 const futureExpirationDate = '2026-12-01T12:00:00.000Z';
 
 const makePipelineRunResponse = (
-  outputs: Record<string, PipelineOutputValue> = {},
+  outputs: Record<string, PipelineOutputValue | PipelineOutputValue[]> = {},
   dataDeliveryReport?: DataDeliveryReport,
   outputExpirationDate?: string
 ): PipelineRunResponse => ({
@@ -90,6 +90,19 @@ describe('DataDeliveryView', () => {
       };
       render(<DataDeliveryView dataDeliveryReport={null} pipelineRunResult={makePipelineRunResponse(outputs)} />);
       expect(screen.getByText('1 file will be moved to the destination.')).toBeInTheDocument();
+    });
+
+    it('counts each file within a FILE_ARRAY output', () => {
+      const outputs = {
+        singleFile: { value: 'gs://bucket/file1.txt', metadata: { sizeInBytes: 1048576 } },
+        fileArray: [
+          { value: 'gs://bucket/chr1.vcf.gz', metadata: { sizeInBytes: 100 } },
+          { value: 'gs://bucket/chr2.vcf.gz', metadata: { sizeInBytes: 200 } },
+          { value: 'gs://bucket/chr3.vcf.gz', metadata: { sizeInBytes: 300 } },
+        ],
+      };
+      render(<DataDeliveryView dataDeliveryReport={null} pipelineRunResult={makePipelineRunResponse(outputs)} />);
+      expect(screen.getByText('4 files will be moved to the destination.')).toBeInTheDocument();
     });
 
     it('does not show file count when there are no outputs', () => {

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/datadelivery/DataDeliveryView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/datadelivery/DataDeliveryView.tsx
@@ -141,7 +141,10 @@ export const DataDeliveryView = ({ dataDeliveryReport: initialReport, pipelineRu
       }
       default: {
         const outputs = pipelineRunResult.pipelineRunReport?.outputs ?? {};
-        const fileCount = Object.keys(outputs).length;
+        const fileCount = Object.values(outputs).reduce(
+          (count, outputValue) => count + (Array.isArray(outputValue) ? outputValue.length : 1),
+          0
+        );
         return (
           <>
             {errorMessage && (

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.test.tsx
@@ -364,6 +364,99 @@ describe('JobOutputsView', () => {
     });
   });
 
+  describe('FILE_ARRAY outputs', () => {
+    beforeEach(() => {
+      mockGetPipelineRunOutputSignedUrls.mockResolvedValue({
+        outputSignedUrls: {
+          imputedMultiSampleVcfArray: [
+            'gs://bucket/test.chr1.vcf.gz',
+            'gs://bucket/test.chr2.vcf.gz',
+            'gs://bucket/test.chr3.vcf.gz',
+            'gs://bucket/test.chr4.vcf.gz',
+            'gs://bucket/test.chr5.vcf.gz',
+          ],
+        },
+      });
+    });
+
+    const fileArrayOutputDefinitions: PipelineOutput[] = [
+      ...mockOutputDefinitions,
+      {
+        name: 'imputedMultiSampleVcfArray',
+        displayName: 'imputed VCFs',
+        type: 'FILE_ARRAY',
+        description: 'per-chr VCFs',
+      },
+    ];
+
+    const buildResultWithFileArray = (files: { value: string; metadata?: { sizeInBytes: number } }[]) => ({
+      ...mockPipelineRunResponse('SUCCEEDED'),
+      pipelineRunReport: {
+        ...mockPipelineRunResponse('SUCCEEDED').pipelineRunReport,
+        outputs: {
+          imputedMultiSampleVcfArray: files,
+        },
+      },
+    });
+
+    it('renders a FILE_ARRAY output with a file count and total size', async () => {
+      const mockResult = buildResultWithFileArray([
+        { value: 'test.chr1.vcf.gz', metadata: { sizeInBytes: 1048576 } },
+        { value: 'test.chr2.vcf.gz', metadata: { sizeInBytes: 1048576 } },
+      ]);
+
+      render(<JobOutputsView outputDefinitions={fileArrayOutputDefinitions} pipelineRunResult={mockResult} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('imputed VCFs')).toBeInTheDocument();
+        expect(screen.getByText('file array')).toBeInTheDocument();
+        expect(screen.getByText(/2 files/)).toBeInTheDocument();
+        expect(screen.getByText(/2\.00 MiB total/)).toBeInTheDocument();
+      });
+    });
+
+    it('collapses long file lists by default and expands on click', async () => {
+      const user = userEvent.setup();
+      const files = [1, 2, 3, 4, 5].map((n) => ({ value: `test.chr${n}.vcf.gz`, metadata: { sizeInBytes: 100 } }));
+      const mockResult = buildResultWithFileArray(files);
+
+      render(<JobOutputsView outputDefinitions={fileArrayOutputDefinitions} pipelineRunResult={mockResult} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('test.chr1.vcf.gz')).toBeInTheDocument();
+        expect(screen.queryByText('test.chr5.vcf.gz')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /show all 5 files/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('test.chr5.vcf.gz')).toBeInTheDocument();
+      });
+    });
+
+    it('opens the details modal for the file that was clicked', async () => {
+      const user = userEvent.setup();
+      const mockResult = buildResultWithFileArray([
+        { value: 'test.chr1.vcf.gz', metadata: { sizeInBytes: 100 } },
+        { value: 'test.chr2.vcf.gz', metadata: { sizeInBytes: 200 } },
+      ]);
+
+      render(<JobOutputsView outputDefinitions={fileArrayOutputDefinitions} pipelineRunResult={mockResult} />);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /view details/i })).toHaveLength(2);
+      });
+
+      const viewDetailsButtons = screen.getAllByRole('button', { name: /view details/i });
+      await user.click(viewDetailsButtons[1]);
+
+      await waitFor(() => {
+        const modal = screen.getByRole('dialog');
+        expect(modal).toHaveTextContent('test.chr2.vcf.gz');
+      });
+    });
+  });
+
   it('does not display file size when sizeInBytes is not available', async () => {
     const mockResult = {
       ...mockPipelineRunResponse('SUCCEEDED'),

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
@@ -1,6 +1,6 @@
 import { Icon, TooltipTrigger } from '@terra-ui-packages/components';
 import React, { useState } from 'react';
-import { PipelineOutput, PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { PipelineOutput, PipelineOutputValue, PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import { formatBytes } from 'src/libs/utils';
 import { PipelineErrorMessage } from 'src/pages/scientificServices/pipelines/common/PipelineErrorMessage';
@@ -14,8 +14,8 @@ interface JobOutputsViewProps {
 }
 
 export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutputsViewProps) => {
-  const [selectedOutput, setSelectedOutput] = useState<{ key: string; fileName: string } | null>(null);
-  const [signedUrls, setSignedUrls] = useState<Record<string, string>>();
+  const [selectedOutput, setSelectedOutput] = useState<{ key: string; fileName: string; index?: number } | null>(null);
+  const [signedUrls, setSignedUrls] = useState<Record<string, string | string[]>>();
 
   const isSucceeded = pipelineRunResult.jobReport.status === 'SUCCEEDED';
   const isFailed = pipelineRunResult.jobReport.status === 'FAILED';
@@ -126,8 +126,6 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
         <div>
           {Object.entries(outputs).map(([key, outputValue]) => {
             const outputDefinition = outputDefinitions.find((output) => output.name === key);
-            const fileName = outputValue.value;
-            const sizeInBytes = outputValue.metadata?.sizeInBytes;
 
             return (
               <div
@@ -141,15 +139,26 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
                   borderRadius: '4px',
                 }}
               >
-                <OutputItem
-                  label={outputDefinition?.displayName || key}
-                  outputType={outputDefinition?.type || 'Unknown'}
-                  tooltip={outputDefinition?.description || 'No description available for this output'}
-                  fileName={fileName}
-                  sizeInBytes={sizeInBytes}
-                  disabled={!isSucceeded || !!outputsExpired}
-                  onSelect={() => setSelectedOutput({ key, fileName })}
-                />
+                {Array.isArray(outputValue) ? (
+                  <OutputArrayItem
+                    label={outputDefinition?.displayName || key}
+                    outputType={outputDefinition?.type || 'FILE_ARRAY'}
+                    tooltip={outputDefinition?.description || 'No description available for this output'}
+                    files={outputValue}
+                    disabled={!isSucceeded || !!outputsExpired}
+                    onSelectFile={(index, fileName) => setSelectedOutput({ key, fileName, index })}
+                  />
+                ) : (
+                  <OutputItem
+                    label={outputDefinition?.displayName || key}
+                    outputType={outputDefinition?.type || 'Unknown'}
+                    tooltip={outputDefinition?.description || 'No description available for this output'}
+                    fileName={outputValue.value}
+                    sizeInBytes={outputValue.metadata?.sizeInBytes}
+                    disabled={!isSucceeded || !!outputsExpired}
+                    onSelect={() => setSelectedOutput({ key, fileName: outputValue.value })}
+                  />
+                )}
               </div>
             );
           })}
@@ -165,6 +174,7 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
           outputKey={selectedOutput.key}
           outputDefinition={outputDefinitions.find((output) => output.name === selectedOutput.key)}
           fileName={selectedOutput.fileName}
+          index={selectedOutput.index}
           pipelineRunResult={pipelineRunResult}
           onDismiss={() => setSelectedOutput(null)}
           signedUrls={signedUrls}
@@ -242,6 +252,113 @@ const OutputItem = ({
         )}
         {disabled && <span style={{ color: colors.dark(0.5), fontStyle: 'italic' }}>Not available</span>}
       </div>
+    </div>
+  );
+};
+
+const COLLAPSED_FILE_COUNT = 3;
+
+const OutputArrayItem = ({
+  label,
+  tooltip,
+  outputType,
+  files,
+  disabled,
+  onSelectFile,
+}: {
+  label: string;
+  tooltip: string;
+  outputType: string;
+  files: PipelineOutputValue[];
+  disabled?: boolean;
+  onSelectFile: (index: number, fileName: string) => void;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const visibleFiles = expanded ? files : files.slice(0, COLLAPSED_FILE_COUNT);
+  const totalSizeInBytes = files.reduce((sum, file) => sum + (file.metadata?.sizeInBytes || 0), 0);
+  const hasSizes = files.some((file) => file.metadata?.sizeInBytes !== undefined);
+
+  return (
+    <div>
+      <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <TooltipTrigger content={tooltip}>
+          <span style={{ fontWeight: 500, textTransform: 'capitalize' }}>{label}</span>
+        </TooltipTrigger>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span style={{ fontSize: 12, color: colors.dark(0.6) }}>
+            {files.length} files{hasSizes && ` · ${formatBytes(totalSizeInBytes)} total`}
+          </span>
+          <PipelineIOTypeBadge type={outputType} />
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+        {visibleFiles.map((file, index) => (
+          <div
+            key={file.value}
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '0.25rem',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              wordBreak: 'break-all',
+            }}
+          >
+            <code style={{ maxWidth: '70%' }} title={file.value}>
+              {file.value}{' '}
+              {file.metadata?.sizeInBytes !== undefined && (
+                <span style={{ fontStyle: 'italic', fontWeight: 'lighter' }}>
+                  ({formatBytes(file.metadata.sizeInBytes)})
+                </span>
+              )}
+            </code>
+            {!disabled && (
+              <div style={{ minWidth: '120px', display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
+                <button
+                  type='button'
+                  onClick={() => onSelectFile(index, file.value)}
+                  style={{
+                    color: '#46A3E9',
+                    fontWeight: 700,
+                    textDecoration: 'underline',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    font: 'inherit',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.25rem',
+                  }}
+                >
+                  <Icon icon='pop-out' size={14} />
+                  View details
+                </button>
+              </div>
+            )}
+            {disabled && <span style={{ color: colors.dark(0.5), fontStyle: 'italic' }}>Not available</span>}
+          </div>
+        ))}
+      </div>
+      {files.length > COLLAPSED_FILE_COUNT && (
+        <button
+          type='button'
+          onClick={() => setExpanded(!expanded)}
+          style={{
+            color: colors.dark(0.6),
+            fontWeight: 500,
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 0,
+            font: 'inherit',
+            marginTop: '0.5rem',
+            textDecoration: 'underline',
+          }}
+        >
+          {expanded ? 'Show fewer files' : `Show all ${files.length} files`}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/pages/scientificServices/pipelines/tabs/history/modals/ViewOutputsModal.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/modals/ViewOutputsModal.test.tsx
@@ -145,6 +145,43 @@ describe('ViewOutputsModal', () => {
     expect(onDismissMock).toHaveBeenCalledTimes(1);
   });
 
+  it('shows a file count and a link to view details for FILE_ARRAY outputs', async () => {
+    const mockOutputs = {
+      output1: { value: 'https://example.com/output1.vcf', metadata: { sizeInBytes: 1048576 } },
+      fileArrayOutput: [
+        { value: 'https://example.com/chr1.vcf', metadata: { sizeInBytes: 100 } },
+        { value: 'https://example.com/chr2.vcf', metadata: { sizeInBytes: 200 } },
+      ],
+    };
+
+    const mockPipelineRunResponse: Partial<PipelineRunResponse> = {
+      pipelineRunReport: {
+        pipelineName: 'test-pipeline',
+        pipelineVersion: 1,
+        toolVersion: '1.0.0',
+        outputExpirationDate: '2025-07-09T00:00:00Z',
+        outputs: mockOutputs,
+      },
+    };
+
+    asMockedFn(Teaspoons).mockReturnValue(
+      partial<TeaspoonsContract>({
+        getPipelineRunResult: jest.fn().mockResolvedValue(mockPipelineRunResponse),
+      })
+    );
+
+    renderWithAppContexts(<ViewOutputsModal jobId={jobId} onDismiss={onDismissMock} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading outputs...')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('2 files')).toBeInTheDocument();
+    expect(screen.getByText('View files')).toBeInTheDocument();
+    // The single-file output still gets a normal download button
+    expect(screen.getAllByText('Download')).toHaveLength(1);
+  });
+
   describe('data delivery', () => {
     const mockOutputs = {
       output1: { value: 'gs://bucket/output1.vcf', metadata: { sizeInBytes: 1048576 } },

--- a/src/pages/scientificServices/pipelines/tabs/history/modals/ViewOutputsModal.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/modals/ViewOutputsModal.tsx
@@ -23,7 +23,7 @@ export const ViewOutputsModal = ({ jobId, onDismiss }: OutputsModalProps): React
   const [result, setResult] = useState<PipelineRunResponse>();
   const [loading, setLoading] = useState(true);
   const [downloadingKey, setDownloadingKey] = useState<string | null>(null);
-  const [signedUrls, setSignedUrls] = useState<Record<string, string>>();
+  const [signedUrls, setSignedUrls] = useState<Record<string, string | string[]>>();
 
   const deliverySucceeded = result?.pipelineRunReport.dataDeliveryReport?.status === 'SUCCEEDED';
 
@@ -54,8 +54,8 @@ export const ViewOutputsModal = ({ jobId, onDismiss }: OutputsModalProps): React
         setSignedUrls(urls);
       }
 
-      const signedUrl = urls[outputKey];
-      if (!signedUrl) {
+      const signedUrl = urls?.[outputKey];
+      if (!signedUrl || Array.isArray(signedUrl)) {
         notify('error', 'There was an error retrieving the download. Please try again.');
         return;
       }
@@ -97,43 +97,58 @@ export const ViewOutputsModal = ({ jobId, onDismiss }: OutputsModalProps): React
                   margin: '1rem 0',
                 }}
               >
-                {Object.entries(result.pipelineRunReport.outputs).map(([key, outputValue]) => (
-                  <div
-                    key={key}
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      padding: '0.5rem',
-                      borderRadius: '4px',
-                      backgroundColor: '#f5f5f5',
-                    }}
-                  >
-                    <div style={{ flex: 1 }}>
-                      <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>{key}</div>
-                      <div
-                        style={{
-                          fontSize: '0.875rem',
-                          color: '#666',
-                          fontFamily: 'monospace',
-                          wordBreak: 'break-all',
-                        }}
-                      >
-                        {outputValue.value}
-                      </div>
-                    </div>
-                    <ButtonPrimary
-                      onClick={() => handleDownload(key)}
-                      disabled={downloadingKey === key || deliverySucceeded}
-                      style={{ marginLeft: '1rem' }}
+                {Object.entries(result.pipelineRunReport.outputs).map(([key, outputValue]) => {
+                  const isFileArray = Array.isArray(outputValue);
+
+                  return (
+                    <div
+                      key={key}
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: '0.5rem',
+                        borderRadius: '4px',
+                        backgroundColor: '#f5f5f5',
+                      }}
                     >
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                        {downloadingKey === key ? <Spinner size={16} /> : <Icon icon='download' size={16} />}
-                        Download
+                      <div style={{ flex: 1 }}>
+                        <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>{key}</div>
+                        <div
+                          style={{
+                            fontSize: '0.875rem',
+                            color: '#666',
+                            fontFamily: 'monospace',
+                            wordBreak: 'break-all',
+                          }}
+                        >
+                          {isFileArray ? `${outputValue.length} files` : outputValue.value}
+                        </div>
                       </div>
-                    </ButtonPrimary>
-                  </div>
-                ))}
+                      {isFileArray ? (
+                        <Link
+                          href={Nav.getLink('pipelines-job-detail', { jobId })}
+                          onClick={onDismiss}
+                          baseColor={() => '#46A3E9'}
+                          style={{ marginLeft: '1rem' }}
+                        >
+                          View files
+                        </Link>
+                      ) : (
+                        <ButtonPrimary
+                          onClick={() => handleDownload(key)}
+                          disabled={downloadingKey === key || deliverySucceeded}
+                          style={{ marginLeft: '1rem' }}
+                        >
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                            {downloadingKey === key ? <Spinner size={16} /> : <Icon icon='download' size={16} />}
+                            Download
+                          </div>
+                        </ButtonPrimary>
+                      )}
+                    </div>
+                  );
+                })}
                 {deliverySucceeded ? (
                   <div
                     style={{

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineIOTypeBadge.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineIOTypeBadge.tsx
@@ -9,6 +9,8 @@ const getTypeColor = (type: PipelineIOType | string): string => {
   switch (type.toUpperCase()) {
     case 'FILE':
       return '#e7f3fb';
+    case 'FILE_ARRAY':
+      return '#d1ecf1';
     case 'STRING':
       return '#f0e7fb';
     case 'FLOAT':
@@ -39,7 +41,7 @@ export const PipelineIOTypeBadge = ({ type }: PipelineIOTypeBadgeProps) => {
           fontSize: 12,
         }}
       >
-        {type.toLowerCase()}
+        {type.toLowerCase().replace(/_/g, ' ')}
       </span>
     </div>
   );

--- a/src/pages/scientificServices/pipelines/utils/mock-file-array-example.ts
+++ b/src/pages/scientificServices/pipelines/utils/mock-file-array-example.ts
@@ -1,0 +1,152 @@
+import {
+  PipelineRunOutputSignedUrlsResponse,
+  PipelineRunResponse,
+  PipelineWithDetails,
+} from 'src/libs/ajax/teaspoons/teaspoons-models';
+
+/**
+ * TSPS-1172: Teaspoons does not yet return FILE_ARRAY outputs. This fixture lets the FILE_ARRAY
+ * rendering in JobDetails be previewed in the running app until the backend ships support for it.
+ * Navigate to the job history detail page for this job ID to see it: #pipelines/imputation/history/mock-file-array-outputs
+ * Remove this file, and its usages in JobDetails.tsx and OutputDetailsModal.tsx, once Teaspoons returns real FILE_ARRAY outputs.
+ */
+export const MOCK_FILE_ARRAY_JOB_ID = 'mock-file-array-outputs';
+
+const chrFileArray = (suffix: string, sizes: number[]) =>
+  sizes.map((sizeInBytes, index) => ({
+    metadata: { sizeInBytes },
+    value: `test.chr${index + 1}.imputed.${suffix}`,
+  }));
+
+export const mockFileArrayPipelineRunResponse: PipelineRunResponse = {
+  jobReport: {
+    id: MOCK_FILE_ARRAY_JOB_ID,
+    description: 'chr split outputs test (local)',
+    status: 'SUCCEEDED',
+    statusCode: 200,
+    submitted: '2026-09-02T14:14:31.675699Z',
+    completed: '2026-09-02T16:01:15.165743Z',
+    resultURL: `http://localhost:8080/api/pipelineruns/v3/result/${MOCK_FILE_ARRAY_JOB_ID}`,
+  },
+  pipelineRunReport: {
+    pipelineName: 'array_imputation',
+    pipelineVersion: 3,
+    toolVersion: 'TSPS-1168_split_chr_output_array_imputation',
+    userInputs: {
+      multiSampleVcf: '/Users/marymorg/Desktop/NA12878_10_duplicate.merged.cleaned.vcf.gz',
+      outputBasename: 'test',
+      minDr2ForInclusion: '0.0',
+    },
+    outputs: {
+      imputedMultiSampleVcfIndex: chrFileArray(
+        'vcf.gz.tbi',
+        [
+          169605, 178017, 146661, 141085, 132976, 126513, 117594, 107501, 90730, 98712, 99221, 98302, 73020, 67368,
+          62660, 60508, 59993, 57345, 41639, 45390, 28446, 27829,
+        ]
+      ),
+      imputedMultiSampleVcf: chrFileArray(
+        'vcf.gz',
+        [
+          43385315, 46276500, 37935463, 37758837, 34737436, 33570214, 31766440, 29650390, 24334849, 26973990, 26295092,
+          25891575, 19082656, 17800196, 16516461, 17811622, 16197104, 15181351, 13435155, 12323769, 8753641, 8655855,
+        ]
+      ),
+      contigsInfo: {
+        metadata: { sizeInBytes: 901 },
+        value: 'test_contig_info.tsv',
+      },
+      chunksInfo: {
+        metadata: { sizeInBytes: 5051 },
+        value: 'test_chunk_info.tsv',
+      },
+    },
+    outputExpirationDate: '2026-09-16T16:01:15.165743Z',
+    quotaConsumed: 500,
+    inputSizeUnits: 'samples',
+    inputSize: 10,
+    citation:
+      'Data Science Services at Broad Clinical Laboratories. (2026, Sep 2). *All of Us + AnVIL Array Imputation* (v3). https://services.terra.bio/',
+  },
+};
+
+export const mockFileArrayPipelineDetails: PipelineWithDetails = {
+  pipelineName: 'array_imputation',
+  displayName: 'Array Imputation',
+  pipelineVersion: 3,
+  description: 'All of Us + AnVIL Array Imputation',
+  type: 'imputation',
+  inputs: [
+    {
+      name: 'multiSampleVcf',
+      displayName: 'multi-sample VCF file',
+      description: 'A bgzipped, multi-sample VCF containing array data from one or more chromosomes to be imputed',
+      type: 'FILE',
+      isRequired: true,
+      fileSuffix: '.vcf.gz',
+    },
+    {
+      name: 'outputBasename',
+      displayName: 'output basename',
+      description:
+        "The prefix for all of the outputs' filenames. May only contain alphanumeric characters, dashes, and underscores",
+      type: 'STRING',
+      isRequired: true,
+    },
+    {
+      name: 'minDr2ForInclusion',
+      displayName: 'minimum imputation quality for inclusion',
+      description:
+        'The minimum imputation quality (DR2) for inclusion in output VCF. Value must be between 0 and 1 (inclusive). Default is 0.0',
+      type: 'FLOAT',
+      isRequired: false,
+      defaultValue: '0.0',
+      minValue: 0,
+      maxValue: 1,
+    },
+  ],
+  outputs: [
+    {
+      name: 'imputedMultiSampleVcf',
+      displayName: 'imputed multi-sample VCFs',
+      type: 'FILE_ARRAY',
+      description: 'One imputed, multi-sample VCF per chromosome',
+    },
+    {
+      name: 'imputedMultiSampleVcfIndex',
+      displayName: 'imputed multi-sample VCF indices',
+      type: 'FILE_ARRAY',
+      description: 'One index file per imputed, multi-sample VCF',
+    },
+    {
+      name: 'contigsInfo',
+      displayName: 'imputation contigs QC tsv',
+      type: 'FILE',
+      description: 'A TSV file containing QC information about the contigs used during imputation',
+    },
+    {
+      name: 'chunksInfo',
+      displayName: 'imputation chunks QC tsv',
+      type: 'FILE',
+      description: 'A TSV file containing QC information about the chunks used during imputation',
+    },
+  ],
+};
+
+const chrSignedUrls = (fileArray: { value: string }[]) =>
+  fileArray.map(({ value }) => `https://storage.googleapis.com/mock-bucket/${value}?mock-signature`);
+
+export const mockFileArrayOutputSignedUrls: PipelineRunOutputSignedUrlsResponse = {
+  jobId: MOCK_FILE_ARRAY_JOB_ID,
+  outputSignedUrls: {
+    imputedMultiSampleVcf: chrSignedUrls(
+      mockFileArrayPipelineRunResponse.pipelineRunReport.outputs!.imputedMultiSampleVcf as { value: string }[]
+    ),
+    imputedMultiSampleVcfIndex: chrSignedUrls(
+      mockFileArrayPipelineRunResponse.pipelineRunReport.outputs!.imputedMultiSampleVcfIndex as { value: string }[]
+    ),
+    contigsInfo: 'https://storage.googleapis.com/mock-bucket/test_contig_info.tsv?mock-signature',
+    chunksInfo: 'https://storage.googleapis.com/mock-bucket/test_chunk_info.tsv?mock-signature',
+  },
+  outputExpirationDate: mockFileArrayPipelineRunResponse.pipelineRunReport.outputExpirationDate!,
+};


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-1172

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Adds support for FILE_ARRAY output types.

Also simplifies the Download flow due to improvements made to the backend in recent months- now the user doesn't have to click "View details" before seeing the Download button.

<img width="3024" height="2342" alt="screencapture-localhost-3000-2026-09-16-10_11_17" src="https://github.com/user-attachments/assets/9d5c9189-9001-40d0-b900-eefbb9a733c1" />




### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
